### PR TITLE
More consistent naming of `Tracer.start_*()` methods with other language implementations

### DIFF
--- a/opentracing/harness/api_check.py
+++ b/opentracing/harness/api_check.py
@@ -71,47 +71,47 @@ class APICompatibilityCheckMixin(object):
                            payload={'hospital': 'Brooklyn Pre-Med Hospital',
                                     'city': 'Old New York'})
 
-    def test_start_active(self):
+    def test_start_active_scope(self):
         # the first usage returns a `Scope` that wraps a root `Span`
         tracer = self.tracer()
-        scope = tracer.start_active(operation_name='Fry')
+        scope = tracer.start_active_scope(operation_name='Fry')
 
         assert scope.span() is not None
         if self.check_scope_manager():
             assert self.is_parent(None, scope.span())
 
-    def test_start_active_parent(self):
+    def test_start_active_scope_parent(self):
         # ensure the `ScopeManager` provides the right parenting
         tracer = self.tracer()
-        with tracer.start_active(operation_name='Fry') as parent:
-            with tracer.start_active(operation_name='Farnsworth') as child:
+        with tracer.start_active_scope(operation_name='Fry') as parent:
+            with tracer.start_active_scope(operation_name='Farnsworth') as child:
                 if self.check_scope_manager():
                     assert self.is_parent(parent.span(), child.span())
 
-    def test_start_active_ignore_active_scope(self):
+    def test_start_active_scope_ignore_active_scope(self):
         # ensure the `ScopeManager` ignores the active `Scope`
         # if the flag is set
         tracer = self.tracer()
-        with tracer.start_active(operation_name='Fry') as parent:
-            with tracer.start_active(operation_name='Farnsworth',
+        with tracer.start_active_scope(operation_name='Fry') as parent:
+            with tracer.start_active_scope(operation_name='Farnsworth',
                                      ignore_active_scope=True) as child:
                 if self.check_scope_manager():
                     assert not self.is_parent(parent.span(), child.span())
 
-    def test_start_active_finish_on_close(self):
+    def test_start_active_scope_finish_on_close(self):
         # ensure a `Span` is finished when the `Scope` close
         tracer = self.tracer()
-        scope = tracer.start_active(operation_name='Fry')
+        scope = tracer.start_active_scope(operation_name='Fry')
         with mock.patch.object(scope.span(), 'finish') as finish:
             scope.close()
 
         if self.check_scope_manager():
             assert finish.call_count == 1
 
-    def test_start_active_not_finish_on_close(self):
+    def test_start_active_scope_not_finish_on_close(self):
         # a `Span` is not finished when the flag is set
         tracer = self.tracer()
-        scope = tracer.start_active(operation_name='Fry',
+        scope = tracer.start_active_scope(operation_name='Fry',
                                     finish_on_close=False)
         with mock.patch.object(scope.span(), 'finish') as finish:
             scope.close()
@@ -121,46 +121,46 @@ class APICompatibilityCheckMixin(object):
     def test_scope_as_context_manager(self):
         tracer = self.tracer()
 
-        with tracer.start_active(operation_name='antiquing') as scope:
+        with tracer.start_active_scope(operation_name='antiquing') as scope:
             assert scope.span() is not None
 
-    def test_start_manual(self):
+    def test_start_span(self):
         tracer = self.tracer()
-        span = tracer.start_manual(operation_name='Fry')
+        span = tracer.start_span(operation_name='Fry')
         span.finish()
-        with tracer.start_manual(operation_name='Fry',
+        with tracer.start_span(operation_name='Fry',
                                  tags={'birthday': 'August 14 1974'}) as span:
             span.log_event('birthplace',
                            payload={'hospital': 'Brooklyn Pre-Med Hospital',
                                     'city': 'Old New York'})
 
-    def test_start_manual_propagation(self):
-        # `start_manual` must inherit the current active `Scope` span
+    def test_start_span_propagation(self):
+        # `start_span` must inherit the current active `Scope` span
         tracer = self.tracer()
-        with tracer.start_active(operation_name='Fry') as parent:
-            with tracer.start_manual(operation_name='Farnsworth') as child:
+        with tracer.start_active_scope(operation_name='Fry') as parent:
+            with tracer.start_span(operation_name='Farnsworth') as child:
                 if self.check_scope_manager():
                     assert self.is_parent(parent.span(), child)
 
-    def test_start_manual_propagation_ignore_active_scope(self):
-        # `start_manual` doesn't inherit the current active `Scope` span
+    def test_start_span_propagation_ignore_active_scope(self):
+        # `start_span` doesn't inherit the current active `Scope` span
         # if the flag is set
         tracer = self.tracer()
-        with tracer.start_active(operation_name='Fry') as parent:
-            with tracer.start_manual(operation_name='Farnsworth',
+        with tracer.start_active_scope(operation_name='Fry') as parent:
+            with tracer.start_span(operation_name='Farnsworth',
                                      ignore_active_scope=True) as child:
                 if self.check_scope_manager():
                     assert not self.is_parent(parent.span(), child)
 
-    def test_start_manual_with_parent(self):
+    def test_start_span_with_parent(self):
         tracer = self.tracer()
-        parent_span = tracer.start_manual(operation_name='parent')
+        parent_span = tracer.start_span(operation_name='parent')
         assert parent_span is not None
-        span = tracer.start_manual(
+        span = tracer.start_span(
             operation_name='Leela',
             child_of=parent_span)
         span.finish()
-        span = tracer.start_manual(
+        span = tracer.start_span(
             operation_name='Leela',
             references=[opentracing.follows_from(parent_span.context)],
             tags={'birthplace': 'sewers'})
@@ -169,7 +169,7 @@ class APICompatibilityCheckMixin(object):
 
     def test_start_child_span(self):
         tracer = self.tracer()
-        parent_span = tracer.start_manual(operation_name='parent')
+        parent_span = tracer.start_span(operation_name='parent')
         assert parent_span is not None
         child_span = opentracing.start_child_span(
             parent_span, operation_name='Leela')
@@ -177,7 +177,7 @@ class APICompatibilityCheckMixin(object):
         parent_span.finish()
 
     def test_set_operation_name(self):
-        span = self.tracer().start_manual().set_operation_name('Farnsworth')
+        span = self.tracer().start_span().set_operation_name('Farnsworth')
         span.finish()
 
     def test_span_as_context_manager(self):
@@ -187,14 +187,14 @@ class APICompatibilityCheckMixin(object):
         def mock_finish(*_):
             finish['called'] = True
 
-        with tracer.start_manual(operation_name='antiquing') as span:
+        with tracer.start_span(operation_name='antiquing') as span:
             setattr(span, 'finish', mock_finish)
         assert finish['called'] is True
 
         # now try with exception
         finish['called'] = False
         try:
-            with tracer.start_manual(operation_name='antiquing') as span:
+            with tracer.start_span(operation_name='antiquing') as span:
                 setattr(span, 'finish', mock_finish)
                 raise ValueError()
         except ValueError:
@@ -203,14 +203,14 @@ class APICompatibilityCheckMixin(object):
             raise AssertionError('Expected ValueError')  # pragma: no cover
 
     def test_span_tag_value_types(self):
-        with self.tracer().start_manual(operation_name='ManyTypes') as span:
+        with self.tracer().start_span(operation_name='ManyTypes') as span:
             span. \
                 set_tag('an_int', 9). \
                 set_tag('a_bool', True). \
                 set_tag('a_string', 'aoeuidhtns')
 
     def test_span_tags_with_chaining(self):
-        span = self.tracer().start_manual(operation_name='Farnsworth')
+        span = self.tracer().start_span(operation_name='Farnsworth')
         span. \
             set_tag('birthday', '9 April, 2841'). \
             set_tag('loves', 'different lengths of wires')
@@ -220,7 +220,7 @@ class APICompatibilityCheckMixin(object):
         span.finish()
 
     def test_span_logs(self):
-        span = self.tracer().start_manual(operation_name='Fry')
+        span = self.tracer().start_span(operation_name='Fry')
 
         # Newer API
         span.log_kv(
@@ -245,7 +245,7 @@ class APICompatibilityCheckMixin(object):
                 payload={'year': 2999})
 
     def test_span_baggage(self):
-        with self.tracer().start_manual(operation_name='Fry') as span:
+        with self.tracer().start_span(operation_name='Fry') as span:
             assert span.context.baggage == {}
             span_ref = span.set_baggage_item('Kiff-loves', 'Amy')
             assert span_ref is span
@@ -255,7 +255,7 @@ class APICompatibilityCheckMixin(object):
             pass
 
     def test_context_baggage(self):
-        with self.tracer().start_manual(operation_name='Fry') as span:
+        with self.tracer().start_span(operation_name='Fry') as span:
             assert span.context.baggage == {}
             span.set_baggage_item('Kiff-loves', 'Amy')
             if self.check_baggage_values():
@@ -263,7 +263,7 @@ class APICompatibilityCheckMixin(object):
             pass
 
     def test_text_propagation(self):
-        with self.tracer().start_manual(operation_name='Bender') as span:
+        with self.tracer().start_span(operation_name='Bender') as span:
             text_carrier = {}
             self.tracer().inject(
                 span_context=span.context,
@@ -275,7 +275,7 @@ class APICompatibilityCheckMixin(object):
             assert extracted_ctx.baggage == {}
 
     def test_binary_propagation(self):
-        with self.tracer().start_manual(operation_name='Bender') as span:
+        with self.tracer().start_span(operation_name='Bender') as span:
             bin_carrier = bytearray()
             self.tracer().inject(
                 span_context=span.context,
@@ -292,7 +292,7 @@ class APICompatibilityCheckMixin(object):
             (Format.HTTP_HEADERS, {}),
             (Format.BINARY, bytearray()),
         ]
-        with self.tracer().start_manual(operation_name='Bender') as span:
+        with self.tracer().start_span(operation_name='Bender') as span:
             for fmt, carrier in formats:
                 # expecting no exceptions
                 span.tracer.inject(span.context, fmt, carrier)
@@ -300,27 +300,27 @@ class APICompatibilityCheckMixin(object):
 
     def test_unknown_format(self):
         custom_format = 'kiss my shiny metal ...'
-        with self.tracer().start_manual(operation_name='Bender') as span:
+        with self.tracer().start_span(operation_name='Bender') as span:
             with pytest.raises(opentracing.UnsupportedFormatException):
                 span.tracer.inject(span.context, custom_format, {})
             with pytest.raises(opentracing.UnsupportedFormatException):
                 span.tracer.extract(custom_format, {})
 
-    def test_tracer_start_active_scope(self):
+    def test_tracer_start_active_scope_scope(self):
         # the Tracer ScopeManager should store the active Scope
         tracer = self.tracer()
-        scope = tracer.start_active(operation_name='Fry')
+        scope = tracer.start_active_scope(operation_name='Fry')
 
         if self.check_scope_manager():
             assert tracer.scope_manager.active() == scope
 
         scope.close()
 
-    def test_tracer_start_active_nesting(self):
+    def test_tracer_start_active_scope_nesting(self):
         # when a Scope is closed, the previous one must be activated
         tracer = self.tracer()
-        with tracer.start_active(operation_name='Fry') as parent:
-            with tracer.start_active(operation_name='Farnsworth'):
+        with tracer.start_active_scope(operation_name='Fry') as parent:
+            with tracer.start_active_scope(operation_name='Farnsworth'):
                 pass
 
             if self.check_scope_manager():
@@ -329,13 +329,13 @@ class APICompatibilityCheckMixin(object):
         if self.check_scope_manager():
             assert tracer.scope_manager.active() is None
 
-    def test_tracer_start_active_nesting_finish_on_close(self):
+    def test_tracer_start_active_scope_nesting_finish_on_close(self):
         # finish_on_close must be correctly handled
         tracer = self.tracer()
-        parent = tracer.start_active(operation_name='Fry',
+        parent = tracer.start_active_scope(operation_name='Fry',
                                      finish_on_close=False)
         with mock.patch.object(parent.span(), 'finish') as finish:
-            with tracer.start_active(operation_name='Farnsworth'):
+            with tracer.start_active_scope(operation_name='Farnsworth'):
                 pass
             parent.close()
 
@@ -344,20 +344,20 @@ class APICompatibilityCheckMixin(object):
         if self.check_scope_manager():
             assert tracer.scope_manager.active() is None
 
-    def test_tracer_start_active_wrong_close_order(self):
+    def test_tracer_start_active_scope_wrong_close_order(self):
         # only the active `Scope` can be closed
         tracer = self.tracer()
-        parent = tracer.start_active(operation_name='Fry')
-        child = tracer.start_active(operation_name='Farnsworth')
+        parent = tracer.start_active_scope(operation_name='Fry')
+        child = tracer.start_active_scope(operation_name='Farnsworth')
         parent.close()
 
         if self.check_scope_manager():
             assert tracer.scope_manager.active() == child
 
-    def test_tracer_start_manual_scope(self):
+    def test_tracer_start_span_scope(self):
         # the Tracer ScopeManager should not store the new Span
         tracer = self.tracer()
-        span = tracer.start_manual(operation_name='Fry')
+        span = tracer.start_span(operation_name='Fry')
 
         if self.check_scope_manager():
             assert tracer.scope_manager.active() is None
@@ -374,7 +374,7 @@ class APICompatibilityCheckMixin(object):
     def test_tracer_scope_manager_activate(self):
         # a `ScopeManager` should activate any `Span`
         tracer = self.tracer()
-        span = tracer.start_manual(operation_name='Fry')
+        span = tracer.start_span(operation_name='Fry')
         tracer.scope_manager.activate(span)
 
         if self.check_scope_manager():

--- a/opentracing/scope_manager.py
+++ b/opentracing/scope_manager.py
@@ -54,7 +54,7 @@ class ScopeManager(object):
         currently active `Scope#span()`.
 
         If there is a non-null `Scope`, its wrapped `Span` becomes an implicit
-        parent of any newly-created `Span` at `Tracer#start_active()`
+        parent of any newly-created `Span` at `Tracer#start_active_scope()`
         time.
 
         :return: the `Scope` that is active, or `None` if not available.

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -50,7 +50,7 @@ class Tracer(object):
         """ScopeManager accessor"""
         return self._scope_manager
 
-    def start_active(self,
+    def start_active_scope(self,
                      operation_name=None,
                      child_of=None,
                      references=None,
@@ -61,7 +61,7 @@ class Tracer(object):
         """Returns a newly started and activated `Scope`.
         Returned `Scope` supports with-statement contexts. For example:
 
-            with tracer.start_active('...') as scope:
+            with tracer.start_active_scope('...') as scope:
                 scope.span().set_tag('http.method', 'GET')
                 do_some_work()
             # Span is finished automatically outside the `Scope` `with`.
@@ -69,7 +69,7 @@ class Tracer(object):
         It's also possible to not finish the `Span` when the `Scope` context
         expires:
 
-            with tracer.start_active('...', finish_on_close=False) as scope:
+            with tracer.start_active_scope('...', finish_on_close=False) as scope:
                 scope.span().set_tag('http.method', 'GET')
                 do_some_work()
             # Span does not finish automatically when the Scope is closed as
@@ -97,7 +97,7 @@ class Tracer(object):
         """
         return self._noop_scope
 
-    def start_manual(self,
+    def start_span(self,
                      operation_name=None,
                      child_of=None,
                      references=None,
@@ -109,19 +109,19 @@ class Tracer(object):
 
         Starting a root Span (a Span with no causal references)::
 
-            tracer.start_manual('...')
+            tracer.start_span('...')
 
 
         Starting a child Span (see also start_child_span())::
 
-            tracer.start_manual(
+            tracer.start_span(
                 '...',
                 child_of=parent_span)
 
 
         Starting a child Span in a more verbose way::
 
-            tracer.start_manual(
+            tracer.start_span(
                 '...',
                 references=[opentracing.child_of(parent_span)])
 
@@ -144,15 +144,6 @@ class Tracer(object):
 
         :return: Returns an already-started Span instance.
         """
-        return self._noop_span
-
-    def start_span(self,
-                   operation_name=None,
-                   child_of=None,
-                   references=None,
-                   tags=None,
-                   start_time=None):
-        """Deprecated: use `start_manual()` or `start_active()` instead."""
         return self._noop_span
 
     def inject(self, span_context, format, carrier):
@@ -218,7 +209,7 @@ class ReferenceType(object):
 class Reference(namedtuple('Reference', ['type', 'referenced_context'])):
     """A Reference pairs a reference type with a referenced SpanContext.
 
-    References are used by Tracer.start_manual() to describe the relationships
+    References are used by Tracer.start_span() to describe the relationships
     between Spans.
 
     Tracer implementations must ignore references where referenced_context is
@@ -227,7 +218,7 @@ class Reference(namedtuple('Reference', ['type', 'referenced_context'])):
     None::
 
         parent_ref = tracer.extract(opentracing.HTTP_HEADERS, request.headers)
-        span = tracer.start_manual(
+        span = tracer.start_span(
             'operation', references=child_of(parent_ref)
         )
 
@@ -243,7 +234,7 @@ def child_of(referenced_context=None):
         If None is passed, this reference must be ignored by the tracer.
 
     :rtype: Reference
-    :return: A Reference suitable for Tracer.start_manual(..., references=...)
+    :return: A Reference suitable for Tracer.start_span(..., references=...)
     """
     return Reference(
         type=ReferenceType.CHILD_OF,
@@ -257,7 +248,7 @@ def follows_from(referenced_context=None):
         If None is passed, this reference must be ignored by the tracer.
 
     :rtype: Reference
-    :return: A Reference suitable for Tracer.start_manual(..., references=...)
+    :return: A Reference suitable for Tracer.start_span(..., references=...)
     """
     return Reference(
         type=ReferenceType.FOLLOWS_FROM,
@@ -269,7 +260,7 @@ def start_child_span(parent_span, operation_name, tags=None, start_time=None):
 
     Equivalent to calling
 
-        parent_span.tracer().start_manual(
+        parent_span.tracer().start_span(
             operation_name,
             references=opentracing.child_of(parent_span.context),
             tags=tags,
@@ -286,7 +277,7 @@ def start_child_span(parent_span, operation_name, tags=None, start_time=None):
 
     :return: Returns an already-started Span instance.
     """
-    return parent_span.tracer.start_manual(
+    return parent_span.tracer.start_span(
         operation_name=operation_name,
         child_of=parent_span,
         tags=tags,

--- a/tests/test_api_check_mixin.py
+++ b/tests/test_api_check_mixin.py
@@ -55,37 +55,37 @@ class VerifyAPICompatibilityCheck(unittest.TestCase):
         setattr(api_check, 'tracer', lambda: Tracer())
 
         # these tests are expected to succeed
-        api_check.test_start_active_ignore_active_scope()
-        api_check.test_start_manual_propagation_ignore_active_scope()
+        api_check.test_start_active_scope_ignore_active_scope()
+        api_check.test_start_span_propagation_ignore_active_scope()
 
         # no-op tracer doesn't have a ScopeManager implementation
         # so these tests are expected to work, but asserts to fail
         with self.assertRaises(AssertionError):
-            api_check.test_start_active()
+            api_check.test_start_active_scope()
 
         with self.assertRaises(AssertionError):
-            api_check.test_start_active_parent()
+            api_check.test_start_active_scope_parent()
 
         with self.assertRaises(AssertionError):
-            api_check.test_start_active_finish_on_close()
+            api_check.test_start_active_scope_finish_on_close()
 
         with self.assertRaises(AssertionError):
-            api_check.test_start_manual_propagation()
+            api_check.test_start_span_propagation()
 
         with self.assertRaises(AssertionError):
-            api_check.test_tracer_start_active_scope()
+            api_check.test_tracer_start_active_scope_scope()
 
         with self.assertRaises(AssertionError):
-            api_check.test_tracer_start_active_nesting()
+            api_check.test_tracer_start_active_scope_nesting()
 
         with self.assertRaises(AssertionError):
-            api_check.test_tracer_start_active_nesting_finish_on_close()
+            api_check.test_tracer_start_active_scope_nesting_finish_on_close()
 
         with self.assertRaises(AssertionError):
-            api_check.test_tracer_start_active_wrong_close_order()
+            api_check.test_tracer_start_active_scope_wrong_close_order()
 
         with self.assertRaises(AssertionError):
-            api_check.test_tracer_start_manual_scope()
+            api_check.test_tracer_start_span_scope()
 
         with self.assertRaises(AssertionError):
             api_check.test_tracer_scope_manager_active()


### PR DESCRIPTION
* Renames `Tracer.start_manual()` => `Tracer.start_span()` so it is more consistent with the Java and Go APIs. This is a clearer indication that a `Span` is returned.
* Renames `Tracer.start_active()` => `Tracer.start_active_scope()` to reflect that a `Scope` is returned.